### PR TITLE
Update swift-syntax to 0.50700.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-        "version" : "0.50600.1"
+        "revision" : "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+        "version" : "0.50700.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-    .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50600.1"),
+    .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50700.1"),
     .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.1")),
     .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -102,8 +102,8 @@ let package = Package(
 
       .binaryTarget(
           name: "lib_InternalSwiftSyntaxParser",
-          url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
-          checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
+          url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.7.1/lib_InternalSwiftSyntaxParser.xcframework.zip",
+          checksum: "feb332ba0a027812b1ee7f552321d6069a46207e5cd0f64fa9bb78e2a261b366"
       ),
   ]
 )

--- a/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
@@ -674,7 +674,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when called on a TypeSyntax node representing a SomeTypeSyntax") {
         final class SomeTypeSyntaxVisitor: SyntaxVisitor {
           var someTypeIdentifier: TypeDescription?
-          override func visit(_ node: SomeTypeSyntax) -> SyntaxVisitorContinueKind {
+          override func visit(_ node: ConstrainedSugarTypeSyntax) -> SyntaxVisitorContinueKind {
             someTypeIdentifier = TypeSyntax(node).typeDescription
             return .skipChildren
           }

--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -357,7 +357,7 @@ extension TypeSyntax {
     } else if let typeIdentifier = self.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
       return .implicitlyUnwrappedOptional(typeIdentifier.wrappedType.typeDescription)
 
-    } else if let typeIdentifier = self.as(SomeTypeSyntax.self) {
+    } else if let typeIdentifier = self.as(ConstrainedSugarTypeSyntax.self) {
       return .some(typeIdentifier.baseType.typeDescription)
 
     } else if let typeIdentifier = self.as(MetatypeTypeSyntax.self) {


### PR DESCRIPTION
The swift-syntax dependency is being updated to 0.50700.1.

All the tests have been successfully run on this set of changes.