### PR TITLE
Update swift-syntax dependency for Swift 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-    .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50700.1"),
+    .package(url: "https://github.com/apple/swift-syntax.git", branch: "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-15-a"),
     .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.1")),
     .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
   ],
@@ -25,7 +25,6 @@ let package = Package(
       name: "SwiftInspector",
       dependencies: [
         "SwiftInspectorCommands",
-        "lib_InternalSwiftSyntaxParser",
       ],
       linkerSettings: [.unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])]),
 
@@ -50,7 +49,7 @@ let package = Package(
       name: "SwiftInspectorAnalyzers",
       dependencies: [
         .product(name: "SwiftSyntax", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
+        .product(name: "SwiftParser", package: "swift-syntax"),
         "SwiftInspectorVisitors",
       ],
       exclude: ["Tests"]),
@@ -70,7 +69,7 @@ let package = Package(
       name: "SwiftInspectorTestHelpers",
       dependencies: [
         .product(name: "SwiftSyntax", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
+        .product(name: "SwiftParser", package: "swift-syntax"),
       ],
       exclude: ["Tests"]),
     .testTarget(
@@ -99,11 +98,5 @@ let package = Package(
       ],
       path: "Sources/SwiftInspectorVisitors/Tests",
       linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "$DT_TOOLCHAIN_DIR/usr/lib/swift/macosx"])]),
-
-      .binaryTarget(
-          name: "lib_InternalSwiftSyntaxParser",
-          url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.7.1/lib_InternalSwiftSyntaxParser.xcframework.zip",
-          checksum: "feb332ba0a027812b1ee7f552321d6069a46207e5cd0f64fa9bb78e2a261b366"
-      ),
   ]
 )

--- a/Sources/SwiftInspectorAnalyzers/CachedSyntaxTree.swift
+++ b/Sources/SwiftInspectorAnalyzers/CachedSyntaxTree.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 import SwiftSyntax
-import SwiftSyntaxParser
+import SwiftParser
 
 /// A type that knows how to return a source file syntax given a file URL
 public final class CachedSyntaxTree {
@@ -48,7 +48,12 @@ public final class CachedSyntaxTree {
   /// 
   /// - Parameter fileURL: The location of the Swift file to parse
   private func memoizeSyntaxTree(at fileURL: URL) throws -> SourceFileSyntax {
-    let cached = try SyntaxParser.parse(fileURL)
+    let fileData = try Data(contentsOf: fileURL)
+    let source = fileData.withUnsafeBytes { buf in
+      return String(decoding: buf.bindMemory(to: UInt8.self), as: UTF8.self)
+    }
+    
+    let cached = Parser.parse(source: source)
     cachedSyntax[fileURL] = cached
     return cached
   }

--- a/Sources/SwiftInspectorAnalyzers/ImportsAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/ImportsAnalyzer.swift
@@ -28,7 +28,7 @@ import SwiftInspectorVisitors
 extension StandardAnalyzer {
 
   public func analyzeImports(fileURL: URL) throws -> [ImportStatement] {
-    let visitor = ImportVisitor()
+    let visitor = ImportVisitor(viewMode: .visitorDefault)
     try analyze(fileURL: fileURL, withVisitor: visitor)
     return visitor.imports
   }

--- a/Sources/SwiftInspectorAnalyzers/InitializerAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/InitializerAnalyzer.swift
@@ -64,8 +64,8 @@ public final class InitializerAnalyzer: Analyzer {
     let functionList = node.children(viewMode: .visitorDefault)
       .compactMap { $0.as(FunctionSignatureSyntax.self) }
       .first?.children(viewMode: .visitorDefault)
-      .compactMap { $0.as(ParameterClauseSyntax.self) }
-      .first?.parameterList
+      .compactMap { $0.as(FunctionParameterClauseSyntax.self) }
+      .first?.parameters
 
     guard let list = functionList else {
       return []
@@ -102,7 +102,7 @@ public final class InitializerAnalyzer: Analyzer {
 
   private func findModifiers(from node: InitializerDeclSyntax) -> Modifiers {
     let modifiersString: [String] = node.children(viewMode: .visitorDefault)
-      .compactMap { $0.as(ModifierListSyntax.self) }
+      .compactMap { $0.as(DeclModifierListSyntax.self) }
       .reduce(into: []) { result, syntax in
         let modifiers = syntax.children(viewMode: .visitorDefault)
           .compactMap { $0.as(DeclModifierSyntax.self) }
@@ -171,15 +171,15 @@ private final class InitializerSyntaxReader: SyntaxVisitor {
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    shouldVisitIdentifier(node.identifier.text) ? .visitChildren : .skipChildren
+    shouldVisitIdentifier(node.name.text) ? .visitChildren : .skipChildren
   }
 
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    shouldVisitIdentifier(node.identifier.text) ? .visitChildren : .skipChildren
+    shouldVisitIdentifier(node.name.text) ? .visitChildren : .skipChildren
   }
 
   override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    shouldVisitIdentifier(node.identifier.text) ? .visitChildren : .skipChildren
+    shouldVisitIdentifier(node.name.text) ? .visitChildren : .skipChildren
   }
 
   override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -192,16 +192,16 @@ private final class InitializerSyntaxReader: SyntaxVisitor {
 }
 
 private final class FunctionParameterReader: SyntaxVisitor {
-  init(onNodeVisit: @escaping (SimpleTypeIdentifierSyntax) -> Void) {
+  init(onNodeVisit: @escaping (IdentifierTypeSyntax) -> Void) {
     self.onNodeVisit = onNodeVisit
     super.init(viewMode: .visitorDefault)
   }
 
-  override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(node)
     return .visitChildren
   }
 
-  let onNodeVisit: (SimpleTypeIdentifierSyntax) -> Void
+  let onNodeVisit: (IdentifierTypeSyntax) -> Void
 
 }

--- a/Sources/SwiftInspectorAnalyzers/StaticUsageAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/StaticUsageAnalyzer.swift
@@ -83,6 +83,7 @@ public struct StaticUsage: Equatable {
 private final class StaticUsageReader: SyntaxVisitor {
   init(onNodeVisit: @escaping (MemberAccessExprSyntax) -> Void) {
     self.onNodeVisit = onNodeVisit
+    super.init(viewMode: .visitorDefault)
   }
 
   override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftInspectorAnalyzers/StaticUsageAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/StaticUsageAnalyzer.swift
@@ -52,9 +52,9 @@ public final class StaticUsageAnalyzer: Analyzer {
     // A MemberAccessExprSyntax contains a base, a dot and a name.
     // The base in this case will be the type of the staticMember, while the name is the member
 
-    let baseNode = node.base?.as(IdentifierExprSyntax.self)
-    let nameText = node.name.text
-    guard let baseText = baseNode?.identifier.text else {
+    let baseNode = node.base?.as(DeclReferenceExprSyntax.self)
+    let nameText = node.declName.baseName.text
+    guard let baseText = baseNode?.baseName.text else {
       return false
     }
 

--- a/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
@@ -34,14 +34,14 @@ final class StandardAnalyzerSpec: QuickSpec {
 
   private final class MockVisitor: SyntaxVisitor {
     var ifStatementSyntaxVisitCount = 0
-    override func visitPost(_ node: IfStmtSyntax) {
+    override func visitPost(_ node: IfExprSyntax) {
       ifStatementSyntaxVisitCount += 1
     }
   }
 
   private final class MockRewriter: SyntaxRewriter {
     var ifStatementSyntaxVisitCount = 0
-    override func visit(_ node: IfStmtSyntax) -> StmtSyntax {
+    override func visit(_ node: IfExprSyntax) -> ExprSyntax {
       ifStatementSyntaxVisitCount += 1
       return super.visit(node)
     }
@@ -61,7 +61,7 @@ final class StandardAnalyzerSpec: QuickSpec {
       }
 
       it("walks the visitor over the content") {
-        let visitor = MockVisitor()
+        let visitor = MockVisitor(viewMode: .visitorDefault)
         try StandardAnalyzer().analyze(fileURL: fileURL, withVisitor: visitor)
 
         expect(visitor.ifStatementSyntaxVisitCount) == 1

--- a/Sources/SwiftInspectorAnalyzers/TypeConformanceAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypeConformanceAnalyzer.swift
@@ -24,6 +24,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftInspectorVisitors
 
 public final class TypeConformanceAnalyzer: Analyzer {
 
@@ -94,6 +95,7 @@ public struct TypeConformance: Equatable {
 private final class TypeConformanceSyntaxVisitor: SyntaxVisitor {
   init(onNodeVisit: @escaping (InheritedTypeSyntax) -> Void) {
     self.onNodeVisit = onNodeVisit
+    super.init(viewMode: .visitorDefault)
   }
 
   override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftInspectorAnalyzers/TypeConformanceAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypeConformanceAnalyzer.swift
@@ -60,7 +60,7 @@ public final class TypeConformanceAnalyzer: Analyzer {
 
   private func isSyntaxNode(_ node: InheritedTypeSyntax, ofType typeName: String) -> Bool {
     // Remove leading and trailing whitespace trivia
-    let syntaxTypeName = String(describing: node.typeName).trimmingCharacters(in: .whitespaces)
+    let syntaxTypeName = String(describing: node.type).trimmingCharacters(in: .whitespaces)
     return (syntaxTypeName == self.typeName)
   }
 
@@ -72,11 +72,11 @@ public final class TypeConformanceAnalyzer: Analyzer {
     // A conforming type can only be a class, struct or enum
     // See: https://docs.swift.org/swift-book/LanguageGuide/Protocols.html
     if let classSyntax = parent.as(ClassDeclSyntax.self) {
-      return classSyntax.identifier.text
+      return classSyntax.name.text
     } else if let structSyntax = parent.as(StructDeclSyntax.self) {
-      return structSyntax.identifier.text
+      return structSyntax.name.text
     } else if let enumSyntax = parent.as(EnumDeclSyntax.self) {
-      return enumSyntax.identifier.text
+      return enumSyntax.name.text
     } else {
       return findConformingType(of: parent.parent)
     }

--- a/Sources/SwiftInspectorAnalyzers/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypeLocationAnalyzer.swift
@@ -64,27 +64,27 @@ private final class TypeLocationSyntaxVisitor: SyntaxVisitor {
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(name: node.identifier.text, keywordToken: node.classKeyword, for: node)
+    processLocatedType(name: node.name.text, keywordToken: node.classKeyword, for: node)
     return .visitChildren
   }
     
   override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(name: node.identifier.text, keywordToken: node.actorKeyword, for: node)
+    processLocatedType(name: node.name.text, keywordToken: node.actorKeyword, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(name: node.identifier.text, keywordToken: node.enumKeyword, for: node)
+    processLocatedType(name: node.name.text, keywordToken: node.enumKeyword, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(name: node.identifier.text, keywordToken: node.protocolKeyword, for: node)
+    processLocatedType(name: node.name.text, keywordToken: node.protocolKeyword, for: node)
     return .visitChildren
   }
 
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(name: node.identifier.text, keywordToken: node.structKeyword, for: node)
+    processLocatedType(name: node.name.text, keywordToken: node.structKeyword, for: node)
     return .visitChildren
   }
 

--- a/Sources/SwiftInspectorAnalyzers/TypealiasAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypealiasAnalyzer.swift
@@ -50,7 +50,7 @@ public final class TypealiasAnalyzer: Analyzer {
   // MARK: Private
   private let cachedSyntaxTree: CachedSyntaxTree
 
-  private func typealiasStatement(from node: TypealiasDeclSyntax) -> TypealiasStatement {
+    private func typealiasStatement(from node: TypeAliasDeclSyntax) -> TypealiasStatement {
     var identifiers: [String] = []
 
     for child in node.children(viewMode: .visitorDefault) {
@@ -61,7 +61,7 @@ public final class TypealiasAnalyzer: Analyzer {
       identifiers = findIdentifiers(from: typeInitializerSyntax)
     }
 
-    return TypealiasStatement(name: node.identifier.text, identifiers:identifiers)
+    return TypealiasStatement(name: node.name.text, identifiers:identifiers)
   }
 
   private func findIdentifiers(from node: TypeInitializerClauseSyntax) -> [String] {
@@ -75,17 +75,17 @@ public final class TypealiasAnalyzer: Analyzer {
 }
 
 private final class TypealiasSyntaxReader: SyntaxVisitor {
-  init(onNodeVisit: @escaping (TypealiasDeclSyntax) -> Void) {
+  init(onNodeVisit: @escaping (TypeAliasDeclSyntax) -> Void) {
     self.onNodeVisit = onNodeVisit
       super.init(viewMode: .visitorDefault)
   }
 
-  override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(node)
     return .visitChildren
   }
 
-  let onNodeVisit: (TypealiasDeclSyntax) -> Void
+  let onNodeVisit: (TypeAliasDeclSyntax) -> Void
 }
 
 public struct TypealiasStatement: Hashable {

--- a/Sources/SwiftInspectorAnalyzers/TypealiasAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypealiasAnalyzer.swift
@@ -24,6 +24,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftInspectorVisitors
 
 public final class TypealiasAnalyzer: Analyzer {
 
@@ -52,7 +53,7 @@ public final class TypealiasAnalyzer: Analyzer {
   private func typealiasStatement(from node: TypealiasDeclSyntax) -> TypealiasStatement {
     var identifiers: [String] = []
 
-    for child in node.children {
+    for child in node.children(viewMode: .visitorDefault) {
       guard let typeInitializerSyntax = child.as(TypeInitializerClauseSyntax.self) else {
         continue
       }
@@ -64,7 +65,7 @@ public final class TypealiasAnalyzer: Analyzer {
   }
 
   private func findIdentifiers(from node: TypeInitializerClauseSyntax) -> [String] {
-    return node.tokens.reduce(into: []) { result, token in
+    return node.tokens(viewMode: .visitorDefault).reduce(into: []) { result, token in
       switch token.tokenKind {
       case .identifier(let name): result.append(name)
       default: return
@@ -76,6 +77,7 @@ public final class TypealiasAnalyzer: Analyzer {
 private final class TypealiasSyntaxReader: SyntaxVisitor {
   init(onNodeVisit: @escaping (TypealiasDeclSyntax) -> Void) {
     self.onNodeVisit = onNodeVisit
+      super.init(viewMode: .visitorDefault)
   }
 
   override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftInspectorAnalyzers/TypesAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypesAnalyzer.swift
@@ -53,6 +53,7 @@ public final class TypesAnalyzer: Analyzer {
 private final class TypeInfoSyntaxVisitor: SyntaxVisitor {
   init(_ onNodeVisit: @escaping (TypeInfo) -> Void) {
     self.onNodeVisit = onNodeVisit
+    super.init(viewMode: .visitorDefault)
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftInspectorAnalyzers/TypesAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypesAnalyzer.swift
@@ -59,7 +59,7 @@ private final class TypeInfoSyntaxVisitor: SyntaxVisitor {
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(.init(
       type: .class,
-      name: node.identifier.text,
+      name: node.name.text,
       comment: comment(from: node.leadingTrivia)))
     return .visitChildren
   }
@@ -67,7 +67,7 @@ private final class TypeInfoSyntaxVisitor: SyntaxVisitor {
   override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(.init(
       type: .enum,
-      name: node.identifier.text,
+      name: node.name.text,
       comment: comment(from: node.leadingTrivia)))
     return .visitChildren
   }
@@ -75,7 +75,7 @@ private final class TypeInfoSyntaxVisitor: SyntaxVisitor {
   override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(.init(
       type: .protocol,
-      name: node.identifier.text,
+      name: node.name.text,
       comment: comment(from: node.leadingTrivia)))
     return .visitChildren
   }
@@ -83,7 +83,7 @@ private final class TypeInfoSyntaxVisitor: SyntaxVisitor {
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(.init(
       type: .struct,
-      name: node.identifier.text,
+      name: node.name.text,
       comment: comment(from: node.leadingTrivia)))
     return .visitChildren
   }

--- a/Sources/SwiftInspectorTestHelpers/SyntaxVisitor+WalkContent.swift
+++ b/Sources/SwiftInspectorTestHelpers/SyntaxVisitor+WalkContent.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 import SwiftSyntax
-import SwiftSyntaxParser
+import SwiftParser
 
 extension SyntaxVisitor {
   /// Walks the visitor along the content's syntax.
@@ -32,7 +32,7 @@ extension SyntaxVisitor {
   /// - Parameters:
   ///   - content: The content to turn into source and walk.
   public func walkContent(_ content: String) throws {
-    let syntax: SourceFileSyntax = try SyntaxParser.parse(source: content)
+    let syntax: SourceFileSyntax = Parser.parse(source: content)
     walk(syntax)
   }
 }

--- a/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
@@ -31,12 +31,12 @@ public final class AssociatedtypeVisitor: SyntaxVisitor {
   public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
     let name = node.identifier.text
 
-    let typeInheritanceVisitor = TypeInheritanceVisitor()
+    let typeInheritanceVisitor = TypeInheritanceVisitor(viewMode: .visitorDefault)
     if let inheritanceClause = node.inheritanceClause {
       typeInheritanceVisitor.walk(inheritanceClause)
     }
 
-    let genericRequirementVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor(viewMode: .visitorDefault)
     if let genericWhereClause = node.genericWhereClause {
       genericRequirementVisitor.walk(genericWhereClause)
     }

--- a/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
@@ -28,8 +28,8 @@ public final class AssociatedtypeVisitor: SyntaxVisitor {
 
   public private(set) var associatedTypes = [AssociatedtypeInfo]()
 
-  public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
-    let name = node.identifier.text
+  public override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
+    let name = node.name.text
 
     let typeInheritanceVisitor = TypeInheritanceVisitor(viewMode: .visitorDefault)
     if let inheritanceClause = node.inheritanceClause {

--- a/Sources/SwiftInspectorVisitors/DeclarationModifierVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/DeclarationModifierVisitor.swift
@@ -35,11 +35,11 @@ final class DeclarationModifierVisitor: SyntaxVisitor {
 
   public override func visit(_ node: DeclModifierSyntax) -> SyntaxVisitorContinueKind {
     if
-      let leftParen = node.detailLeftParen,
-      let detail = node.detail,
-      let rightParen = node.detailRightParen
+      let leftParen = node.detail?.leftParen,
+      let detail = node.detail?.detail,
+      let rightParen = node.detail?.rightParen
     {
-      rawModifiers.append(node.name.text + leftParen.text + detail.text + rightParen.text)
+      rawModifiers.append(node.name.text + leftParen.text + detail.description + rightParen.text)
     } else {
       rawModifiers.append(node.name.text)
     }

--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -90,7 +90,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     let typealiasVisitor = TypealiasVisitor(parentType: extensionInfo?.typeDescription)
     typealiasVisitor.walk(node)
 

--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -45,20 +45,18 @@ public final class ExtensionVisitor: SyntaxVisitor {
       return .skipChildren
     }
 
-    let typeInheritanceVisitor = TypeInheritanceVisitor()
+    let typeInheritanceVisitor = TypeInheritanceVisitor(viewMode: .visitorDefault)
     if let inheritanceClause = node.inheritanceClause {
       typeInheritanceVisitor.walk(inheritanceClause)
     }
 
-    let genericRequirementVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor(viewMode: .visitorDefault)
     if let genericWhereClause = node.genericWhereClause {
       genericRequirementVisitor.walk(genericWhereClause)
     }
 
-    let declarationModifierVisitor = DeclarationModifierVisitor()
-    if let modifiers = node.modifiers {
-      declarationModifierVisitor.walk(modifiers)
-    }
+    let declarationModifierVisitor = DeclarationModifierVisitor(viewMode: .visitorDefault)
+    declarationModifierVisitor.walk(node.modifiers)
 
     extensionInfo = ExtensionInfo(
       typeDescription: node.extendedType.typeDescription,
@@ -103,7 +101,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-    let propertyVisitor = PropertyVisitor()
+    let propertyVisitor = PropertyVisitor(viewMode: .visitorDefault)
     propertyVisitor.walk(node)
 
     extensionInfo?.properties.append(contentsOf: propertyVisitor.properties)
@@ -113,7 +111,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let functionDeclarationVisitor = FunctionDeclarationVisitor()
+    let functionDeclarationVisitor = FunctionDeclarationVisitor(viewMode: .visitorDefault)
     functionDeclarationVisitor.walk(node)
 
     extensionInfo?.functionDeclarations.append(contentsOf: functionDeclarationVisitor.functionDeclarations)

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -91,7 +91,7 @@ public final class FileVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     let typealiasVisitor = TypealiasVisitor()
     typealiasVisitor.walk(node)
 

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -29,12 +29,13 @@ public final class FileVisitor: SyntaxVisitor {
 
   public init(fileURL: URL) {
     fileInfo = FileInfo(url: fileURL)
+    super.init(viewMode: .visitorDefault)
   }
 
   public private(set) var fileInfo: FileInfo
 
   public override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
-    let importVisitor = ImportVisitor()
+    let importVisitor = ImportVisitor(viewMode: .visitorDefault)
     importVisitor.walk(node)
 
     fileInfo.appendImports(importVisitor.imports)
@@ -43,7 +44,7 @@ public final class FileVisitor: SyntaxVisitor {
     return .skipChildren
   }
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    let protocolVisitor = ProtocolVisitor()
+    let protocolVisitor = ProtocolVisitor(viewMode: .visitorDefault)
     protocolVisitor.walk(node)
 
     if let protocolInfo = protocolVisitor.protocolInfo {
@@ -56,7 +57,7 @@ public final class FileVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let visitor = FunctionDeclarationVisitor()
+    let visitor = FunctionDeclarationVisitor(viewMode: .visitorDefault)
     visitor.walk(node)
     fileInfo.appendFreeFunctions(visitor.functionDeclarations)
     return .skipChildren
@@ -75,7 +76,7 @@ public final class FileVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let extensionVisitor = ExtensionVisitor()
+    let extensionVisitor = ExtensionVisitor(viewMode: .visitorDefault)
     extensionVisitor.walk(node)
 
     if let extensionInfo = extensionVisitor.extensionInfo {

--- a/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 public final class FunctionDeclarationVisitor: SyntaxVisitor {
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let name = node.identifier.text
+    let name = node.name.text
 
     let functionSignatureVisitor = FunctionSignatureVisitor(viewMode: .visitorDefault)
     functionSignatureVisitor.walk(node)
@@ -58,7 +58,7 @@ fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
     return .skipChildren
   }
   override func visit(_ node: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
-    returnType = node.returnType.typeDescription
+    returnType = node.type.typeDescription
     return .skipChildren
   }
 

--- a/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
@@ -2,15 +2,13 @@ import SwiftSyntax
 
 public final class FunctionDeclarationVisitor: SyntaxVisitor {
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let name = node.identifier.withoutTrivia().description
+    let name = node.identifier.text
 
-    let functionSignatureVisitor = FunctionSignatureVisitor()
+    let functionSignatureVisitor = FunctionSignatureVisitor(viewMode: .visitorDefault)
     functionSignatureVisitor.walk(node)
 
-    let modifiersVisitor = DeclarationModifierVisitor()
-    if let modifiers = node.modifiers {
-      modifiersVisitor.walk(modifiers)
-    }
+    let modifiersVisitor = DeclarationModifierVisitor(viewMode: .visitorDefault)
+    modifiersVisitor.walk(node.modifiers)
 
     let info = FunctionDeclarationInfo(
       modifiers: modifiersVisitor.modifiers,
@@ -51,10 +49,8 @@ public final class FunctionDeclarationVisitor: SyntaxVisitor {
 
 fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
   override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
-    guard
-      let firstMember = node.firstName?.text,
-      let type = node.type?.typeDescription
-    else { return .skipChildren }
+    let firstMember = node.firstName.text
+    let type = node.type.typeDescription
 
     let secondMember = node.secondName?.text
 

--- a/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
@@ -41,7 +41,7 @@ public final class GenericRequirementVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  public override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
     // A member declaration block means we've found the body of the type.
     // There's nothing in this body that would help us determine generic requirements.
     .skipChildren
@@ -53,14 +53,14 @@ public struct GenericRequirement: Codable, Hashable {
   // MARK: Lifecycle
 
   init(node: SameTypeRequirementSyntax) {
-    leftType = node.leftTypeIdentifier.typeDescription
-    rightType = node.rightTypeIdentifier.typeDescription
+    leftType = node.leftType.typeDescription
+    rightType = node.rightType.typeDescription
     relationship = .equals
   }
 
   init(node: ConformanceRequirementSyntax) {
-    leftType = node.leftTypeIdentifier.typeDescription
-    rightType = node.rightTypeIdentifier.typeDescription
+    leftType = node.leftType.typeDescription
+    rightType = node.rightType.typeDescription
     relationship = .conformsTo
   }
 

--- a/Sources/SwiftInspectorVisitors/ImportVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ImportVisitor.swift
@@ -70,17 +70,17 @@ public final class ImportVisitor: SyntaxVisitor {
   ///            e.g `import class UIKit.UIViewController` returns class
   ///            while `import UIKit` and `import UIKit.UIViewController` return an empty String
   private func findImportKind(from syntaxNode: ImportDeclSyntax) -> String {
-    for token in syntaxNode.tokens {
+    for token in syntaxNode.tokens(viewMode: .visitorDefault) {
       switch token.tokenKind {
       // List is from https://thoughtbot.com/blog/swift-imports
-      case .typealiasKeyword,
-           .structKeyword,
-           .classKeyword,
-           .enumKeyword,
-           .protocolKeyword,
-           .letKeyword,
-           .varKeyword,
-           .funcKeyword:
+      case .keyword(.typealias),
+            .keyword(.struct),
+            .keyword(.class),
+            .keyword(.enum),
+            .keyword(.protocol),
+            .keyword(.let),
+            .keyword(.var),
+            .keyword(.func):
         return token.text
       default:
         break
@@ -100,7 +100,7 @@ public final class ImportVisitor: SyntaxVisitor {
     var moduleIdentifier: String = ""
     var submoduleIdentifier: String = ""
 
-    for child in syntaxNode.children {
+    for child in syntaxNode.children(viewMode: .visitorDefault) {
       guard let accessPath = child.as(AccessPathSyntax.self) else {
         continue
       }
@@ -121,14 +121,14 @@ public final class ImportVisitor: SyntaxVisitor {
   }
 
   private func findAttribute(from syntaxNode: ImportDeclSyntax) -> String {
-    for child in syntaxNode.children {
+    for child in syntaxNode.children(viewMode: .visitorDefault) {
       guard let attributeList = child.as(AttributeListSyntax.self) else {
         continue
       }
 
       // This AttributeList is of the form ["@", "attribute"]
       // So we grab the last token
-      return attributeList.lastToken?.text ?? ""
+      return attributeList.lastToken(viewMode: .visitorDefault)?.text ?? ""
     }
     return ""
   }

--- a/Sources/SwiftInspectorVisitors/ImportVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ImportVisitor.swift
@@ -101,7 +101,7 @@ public final class ImportVisitor: SyntaxVisitor {
     var submoduleIdentifier: String = ""
 
     for child in syntaxNode.children(viewMode: .visitorDefault) {
-      guard let accessPath = child.as(AccessPathSyntax.self) else {
+      guard let accessPath = child.as(ImportPathComponentListSyntax.self) else {
         continue
       }
 

--- a/Sources/SwiftInspectorVisitors/NestableDeclSyntax.swift
+++ b/Sources/SwiftInspectorVisitors/NestableDeclSyntax.swift
@@ -25,21 +25,15 @@
 import SwiftSyntax
 
 protocol NestableDeclSyntax: SyntaxProtocol {
-  var modifiers: ModifierListSyntax? { get }
+  var modifiers: DeclModifierListSyntax { get }
   var identifier: TokenSyntax { get }
-  var inheritanceClause: TypeInheritanceClauseSyntax? { get }
+  var inheritanceClause: InheritanceClauseSyntax? { get }
   var genericParameterClause: GenericParameterClauseSyntax? { get }
   var genericWhereClause: GenericWhereClauseSyntax? { get }
-  var members: MemberDeclBlockSyntax { get }
+  var members: MemberBlockSyntax { get }
 }
 
 extension ClassDeclSyntax: NestableDeclSyntax {}
 extension StructDeclSyntax: NestableDeclSyntax {}
-extension EnumDeclSyntax: NestableDeclSyntax {
-  var genericParameterClause: GenericParameterClauseSyntax? {
-    // Not sure why enums's `GenericParameterClauseSyntax` has a different
-    // accessor name, but it does. So let's remap.
-    genericParameters
-  }
-}
+extension EnumDeclSyntax: NestableDeclSyntax {}
 

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -88,7 +88,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     guard
       !topLevelParsingTracker.hasFinishedParsing,
       let topLevelDeclarationName = topLevelDeclaration?.nestableInfo.name

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -29,6 +29,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
 
   public init(parentType: TypeDescription? = nil) {
     self.parentType = parentType
+    super.init(viewMode: .visitorDefault)
   }
 
   deinit {
@@ -112,7 +113,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
       return .skipChildren
     }
 
-    let visitor = PropertyVisitor()
+    let visitor = PropertyVisitor(viewMode: .visitorDefault)
     visitor.walk(node)
 
     self.topLevelDeclaration = topLevelDeclaration
@@ -128,7 +129,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
       return .skipChildren
     }
 
-    let visitor = FunctionDeclarationVisitor()
+    let visitor = FunctionDeclarationVisitor(viewMode: .visitorDefault)
     visitor.walk(node)
 
     self.topLevelDeclaration = topLevelDeclaration
@@ -171,22 +172,20 @@ public final class NestableTypeVisitor: SyntaxVisitor {
     } else {
       // Recursive case. This is the first top-level declaration we've come across.
       // We need to get its information and then visit children to see if there is more information we need.
-      let typeInheritanceVisitor = TypeInheritanceVisitor()
+      let typeInheritanceVisitor = TypeInheritanceVisitor(viewMode: .visitorDefault)
       if let inheritanceClause = node.inheritanceClause {
         typeInheritanceVisitor.walk(inheritanceClause)
       }
 
-      let declarationModifierVisitor = DeclarationModifierVisitor()
-      if let modifiers = node.modifiers {
-        declarationModifierVisitor.walk(modifiers)
-      }
+      let declarationModifierVisitor = DeclarationModifierVisitor(viewMode: .visitorDefault)
+      declarationModifierVisitor.walk(node.modifiers)
 
-      let genericParameterVisitor = GenericParameterVisitor()
+      let genericParameterVisitor = GenericParameterVisitor(viewMode: .visitorDefault)
       if let genericParameterClause = node.genericParameterClause {
         genericParameterVisitor.walk(genericParameterClause)
       }
 
-      let genericRequirementVisitor = GenericRequirementVisitor()
+      let genericRequirementVisitor = GenericRequirementVisitor(viewMode: .visitorDefault)
       if let genericWhereClause = node.genericWhereClause {
         genericRequirementVisitor.walk(genericWhereClause)
       }

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -157,7 +157,7 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   private func findPropertyType(from node: VariableDeclSyntax) -> PropertyType {
-    if let type = PropertyType(rawValue: node.bindingKeyword.text) {
+    if let type = PropertyType(rawValue: node.bindingSpecifier.text) {
       return type
     }
     else {
@@ -199,8 +199,8 @@ private final class PatternBindingListVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: AccessorDeclSyntax) -> SyntaxVisitorContinueKind {
-    if node.accessorKind.text == "get" { protocolRequirements.insert(.gettable) }
-    if node.accessorKind.text == "set" { protocolRequirements.insert(.settable) }
+    if node.accessorSpecifier.text == "get" { protocolRequirements.insert(.gettable) }
+    if node.accessorSpecifier.text == "set" { protocolRequirements.insert(.settable) }
     return .skipChildren
   }
 

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -86,10 +86,8 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   private func findModifiers(from node: VariableDeclSyntax) -> Modifiers {
-    let modifiersVisitor = DeclarationModifierVisitor()
-    if let modifiers = node.modifiers {
-      modifiersVisitor.walk(modifiers)
-    }
+    let modifiersVisitor = DeclarationModifierVisitor(viewMode: .visitorDefault)
+    modifiersVisitor.walk(node.modifiers)
 
     var modifiers = modifiersVisitor.modifiers
 
@@ -124,7 +122,7 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   private func findParadigm(from node: VariableDeclSyntax) -> PropertyInfo.Paradigm {
-    let patternBindingListVisitor = PatternBindingListVisitor()
+    let patternBindingListVisitor = PatternBindingListVisitor(viewMode: .visitorDefault)
     patternBindingListVisitor.walk(node.bindings)
 
     assert(
@@ -159,7 +157,7 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   private func findPropertyType(from node: VariableDeclSyntax) -> PropertyType {
-    if let type = PropertyType(rawValue: node.letOrVarKeyword.text) {
+    if let type = PropertyType(rawValue: node.bindingKeyword.text) {
       return type
     }
     else {
@@ -191,12 +189,12 @@ private final class PatternBindingListVisitor: SyntaxVisitor {
   private(set) var protocolRequirements: ProtocolRequirements = []
 
   public override func visit(_ node: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
-    codeBlockDescription = node.withoutTrivia().description
+    codeBlockDescription = node.trimmed.description
     return .skipChildren
   }
 
   public override func visit(_ node: InitializerClauseSyntax) -> SyntaxVisitorContinueKind {
-    initializerDescription = node.withEqual(nil).description
+    initializerDescription = node.value.description
     return .skipChildren
   }
 

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -86,7 +86,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: AssociatedTypeDeclSyntax) -> SyntaxVisitorContinueKind {
     let associatedtypeVisitor = AssociatedtypeVisitor(viewMode: .visitorDefault)
     associatedtypeVisitor.walk(node)
     associatedtypes.append(contentsOf: associatedtypeVisitor.associatedTypes)
@@ -95,7 +95,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
     let typealiasVisitor = TypealiasVisitor(parentType: parentType)
     typealiasVisitor.walk(node)
     typealiases.append(contentsOf: typealiasVisitor.typealiases)

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -45,26 +45,24 @@ public final class ProtocolVisitor: SyntaxVisitor {
       assertionFailureOrPostNotification("Encountered more than one top-level protocol. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
       return .skipChildren
     }
-    let name = node.identifier.text
+    let name = node.name.text
     self.name = name
     parentType = .simple(name: name)
 
-    let typeInheritanceVisitor = TypeInheritanceVisitor()
+    let typeInheritanceVisitor = TypeInheritanceVisitor(viewMode: .visitorDefault)
     if let inheritanceClause = node.inheritanceClause {
       typeInheritanceVisitor.walk(inheritanceClause)
       inheritsFromTypes = typeInheritanceVisitor.inheritsFromTypes
     }
-    let genericRequirementVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor(viewMode: .visitorDefault)
     if let genericWhereClause = node.genericWhereClause {
       genericRequirementVisitor.walk(genericWhereClause)
       genericRequirements = genericRequirementVisitor.genericRequirements
     }
 
-    let declarationModifierVisitor = DeclarationModifierVisitor()
-    if let modifiers = node.modifiers {
-      declarationModifierVisitor.walk(modifiers)
-      self.modifiers = declarationModifierVisitor.modifiers
-    }
+    let declarationModifierVisitor = DeclarationModifierVisitor(viewMode: .visitorDefault)
+    declarationModifierVisitor.walk(node.modifiers)
+    self.modifiers = declarationModifierVisitor.modifiers
 
     return .visitChildren
   }
@@ -89,7 +87,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: AssociatedtypeDeclSyntax) -> SyntaxVisitorContinueKind {
-    let associatedtypeVisitor = AssociatedtypeVisitor()
+    let associatedtypeVisitor = AssociatedtypeVisitor(viewMode: .visitorDefault)
     associatedtypeVisitor.walk(node)
     associatedtypes.append(contentsOf: associatedtypeVisitor.associatedTypes)
 
@@ -107,7 +105,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-    let propertiesVisitor = PropertyVisitor()
+    let propertiesVisitor = PropertyVisitor(viewMode: .visitorDefault)
     propertiesVisitor.walk(node)
     properties.append(contentsOf: propertiesVisitor.properties)
 
@@ -116,7 +114,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-    let visitor = FunctionDeclarationVisitor()
+    let visitor = FunctionDeclarationVisitor(viewMode: .visitorDefault)
     visitor.walk(node)
     let functions = visitor.functionDeclarations
     functionDeclarations.append(contentsOf: functions)

--- a/Sources/SwiftInspectorVisitors/SyntaxTreeViewMode+Ext.swift
+++ b/Sources/SwiftInspectorVisitors/SyntaxTreeViewMode+Ext.swift
@@ -1,0 +1,16 @@
+//
+//  SyntaxTreeViewMode+Ext.swift
+//
+//
+//  Created by Pablo Cornejo on 8/21/23.
+//
+
+import SwiftSyntax
+
+public extension SyntaxTreeViewMode {
+    /// The view mode that should be used as the default for all syntax visitors.
+    ///
+    /// Using this variable allows to have the default centralized here
+    /// so that it can be more easily changed if ever needed.
+    static let visitorDefault: SyntaxTreeViewMode = .fixedUp
+}

--- a/Sources/SwiftInspectorVisitors/Tests/AssociatedtypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/AssociatedtypeVisitorSpec.swift
@@ -29,11 +29,11 @@ import SwiftInspectorTestHelpers
 @testable import SwiftInspectorVisitors
 
 final class AssociatedtypeVisitorSpec: QuickSpec {
-  private var sut = AssociatedtypeVisitor()
+  private var sut = AssociatedtypeVisitor(viewMode: .visitorDefault)
 
   override func spec() {
     beforeEach {
-      self.sut = AssociatedtypeVisitor()
+      self.sut = AssociatedtypeVisitor(viewMode: .visitorDefault)
     }
 
     describe("visit(_:)") {

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -30,11 +30,11 @@ import SwiftInspectorTestHelpers
 @testable import SwiftInspectorVisitors
 
 final class ExtensionVisitorSpec: QuickSpec {
-  private var sut = ExtensionVisitor()
+  private var sut = ExtensionVisitor(viewMode: .visitorDefault)
 
   override func spec() {
     beforeEach {
-      self.sut = ExtensionVisitor()
+      self.sut = ExtensionVisitor(viewMode: .visitorDefault)
       AssertionFailure.postNotification = true
     }
 

--- a/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
@@ -9,7 +9,7 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
 
   override func spec() {
     beforeEach {
-      self.sut = FunctionDeclarationVisitor()
+      self.sut = FunctionDeclarationVisitor(viewMode: .visitorDefault)
       AssertionFailure.postNotification = true
     }
 

--- a/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
@@ -30,11 +30,11 @@ import SwiftInspectorTestHelpers
 @testable import SwiftInspectorVisitors
 
 final class GenericRequirementVisitorSpec: QuickSpec {
-  private var sut = GenericRequirementVisitor()
+  private var sut = GenericRequirementVisitor(viewMode: .visitorDefault)
 
   override func spec() {
     beforeEach {
-      self.sut = GenericRequirementVisitor()
+      self.sut = GenericRequirementVisitor(viewMode: .visitorDefault)
     }
 
     describe("visit(_:)") {

--- a/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
@@ -30,11 +30,11 @@ import SwiftInspectorTestHelpers
 @testable import SwiftInspectorVisitors
 
 final class ImportVisitorSpec: QuickSpec {
-  private var sut = ImportVisitor()
+  private var sut = ImportVisitor(viewMode: .visitorDefault)
 
   override func spec() {
     beforeEach {
-      self.sut = ImportVisitor()
+      self.sut = ImportVisitor(viewMode: .visitorDefault)
     }
 
     describe("visit") {

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -36,7 +36,7 @@ final class PropertyVisitorSpec: QuickSpec {
       var sut: PropertyVisitor!
 
       beforeEach {
-        sut = PropertyVisitor()
+        sut = PropertyVisitor(viewMode: .visitorDefault)
         AssertionFailure.postNotification = true
       }
 
@@ -458,6 +458,7 @@ private final class TestProtocolVisitor: SyntaxVisitor {
 
   init(propertyVisitor: PropertyVisitor) {
     self.propertyVisitor = propertyVisitor
+    super.init(viewMode: .visitorDefault)
   }
 
   override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
@@ -30,11 +30,11 @@ import SwiftInspectorTestHelpers
 @testable import SwiftInspectorVisitors
 
 final class ProtocolVisitorSpec: QuickSpec {
-  private var sut = ProtocolVisitor()
+  private var sut = ProtocolVisitor(viewMode: .visitorDefault)
 
   override func spec() {
     beforeEach {
-      self.sut = ProtocolVisitor()
+      self.sut = ProtocolVisitor(viewMode: .visitorDefault)
       AssertionFailure.postNotification = true
     }
 

--- a/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
@@ -470,7 +470,7 @@ final class TypeDescriptionSpec: QuickSpec {
               var int: Int = 1
               """
 
-          visitor = SimpleTypeIdentifierSyntaxVisitor()
+          visitor = SimpleTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -495,7 +495,7 @@ final class TypeDescriptionSpec: QuickSpec {
               var int: Swift.Int = 1
               """
 
-            visitor = MemberTypeIdentifierSyntaxVisitor()
+            visitor = MemberTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -510,7 +510,7 @@ final class TypeDescriptionSpec: QuickSpec {
               var intArray: Swift.Array<Int> = [1]
               """
 
-            visitor = MemberTypeIdentifierSyntaxVisitor()
+            visitor = MemberTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -525,7 +525,7 @@ final class TypeDescriptionSpec: QuickSpec {
               var genericType: OuterGenericType<Int>.InnerType
               """
 
-            visitor = MemberTypeIdentifierSyntaxVisitor()
+            visitor = MemberTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -540,7 +540,7 @@ final class TypeDescriptionSpec: QuickSpec {
               var genericType: OuterGenericType<Int>.InnerGenericType<String>
               """
 
-            visitor = MemberTypeIdentifierSyntaxVisitor()
+            visitor = MemberTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -567,7 +567,7 @@ final class TypeDescriptionSpec: QuickSpec {
             protocol FooBar: Foo & Bar
             """
 
-          visitor = CompositionTypeSyntaxVisitor()
+          visitor = CompositionTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -594,7 +594,7 @@ final class TypeDescriptionSpec: QuickSpec {
             protocol FooBar: Foo where Something == AnyObject? {}
             """
 
-          visitor = OptionalTypeSyntaxVisitor()
+          visitor = OptionalTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -621,7 +621,7 @@ final class TypeDescriptionSpec: QuickSpec {
             var int: Int!
             """
 
-          visitor = ImplicitlyUnwrappedOptionalTypeSyntaxVisitor()
+          visitor = ImplicitlyUnwrappedOptionalTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -646,7 +646,7 @@ final class TypeDescriptionSpec: QuickSpec {
             let metatype: Int.Type
             """
 
-            visitor = MetatypeTypeSyntaxVisitor()
+            visitor = MetatypeTypeSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -661,7 +661,7 @@ final class TypeDescriptionSpec: QuickSpec {
             let metatype: Equatable.Protocol
             """
 
-            visitor = MetatypeTypeSyntaxVisitor()
+            visitor = MetatypeTypeSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -686,7 +686,7 @@ final class TypeDescriptionSpec: QuickSpec {
             func makeSomething() -> some Equatable { "" }
             """
 
-          visitor = SomeTypeSyntaxVisitor()
+          visitor = SomeTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -708,10 +708,10 @@ final class TypeDescriptionSpec: QuickSpec {
         context("with a specifier") {
           beforeEach {
             let content = """
-            inout Int
+            (inout Int)
             """
 
-            visitor = AttributedTypeSyntaxVisitor()
+            visitor = AttributedTypeSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -726,7 +726,7 @@ final class TypeDescriptionSpec: QuickSpec {
             @autoclosure () -> Void
             """
 
-            visitor = AttributedTypeSyntaxVisitor()
+            visitor = AttributedTypeSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -738,10 +738,10 @@ final class TypeDescriptionSpec: QuickSpec {
             beforeEach {
               let content = """
               // This code doesn't compile but it can be parsed.
-              inout @autoclosure () -> Void
+              (inout @autoclosure () -> Void)
               """
 
-              visitor = AttributedTypeSyntaxVisitor()
+              visitor = AttributedTypeSyntaxVisitor(viewMode: .visitorDefault)
               try? visitor.walkContent(content)
             }
 
@@ -767,7 +767,7 @@ final class TypeDescriptionSpec: QuickSpec {
             var intArray: [Int] = [Int]()
             """
 
-          visitor = ArrayTypeSyntaxVisitor()
+          visitor = ArrayTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -792,7 +792,7 @@ final class TypeDescriptionSpec: QuickSpec {
             var intArray: Array<Int>
             """
 
-            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            visitor = SimpleTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -807,7 +807,7 @@ final class TypeDescriptionSpec: QuickSpec {
             var twoDimensionalIntArray: Array<Array<Int>>
             """
 
-            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            visitor = SimpleTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -833,7 +833,7 @@ final class TypeDescriptionSpec: QuickSpec {
             var dictionary: [Int: String] = [Int: String]()
             """
 
-          visitor = DictionaryTypeSyntaxVisitor()
+          visitor = DictionaryTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -858,7 +858,7 @@ final class TypeDescriptionSpec: QuickSpec {
             var dictionary: Dictionary<Int, String>
             """
 
-            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            visitor = SimpleTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -873,7 +873,7 @@ final class TypeDescriptionSpec: QuickSpec {
             var twoDimensionalDictionary: Dictionary<Int, Dictionary<Int, String>>
             """
 
-            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            visitor = SimpleTypeIdentifierSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -900,7 +900,7 @@ final class TypeDescriptionSpec: QuickSpec {
               var tuple: (Int, String)
               """
 
-          visitor = TupleTypeSyntaxVisitor()
+          visitor = TupleTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -926,7 +926,7 @@ final class TypeDescriptionSpec: QuickSpec {
               protocol SomeObject: class {}
               """
 
-          visitor = ClassRestrictionTypeSyntaxVisitor()
+          visitor = ClassRestrictionTypeSyntaxVisitor(viewMode: .visitorDefault)
           try? visitor.walkContent(content)
         }
 
@@ -953,7 +953,7 @@ final class TypeDescriptionSpec: QuickSpec {
                 var test: (Int, Double) -> String
                 """
 
-            visitor = FunctionTypeSyntaxVisitor()
+            visitor = FunctionTypeSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 
@@ -969,7 +969,7 @@ final class TypeDescriptionSpec: QuickSpec {
                 var test: (Int, Double) throws -> String
                 """
 
-            visitor = FunctionTypeSyntaxVisitor()
+            visitor = FunctionTypeSyntaxVisitor(viewMode: .visitorDefault)
             try? visitor.walkContent(content)
           }
 

--- a/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
@@ -458,7 +458,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when called on a TypeSyntax node representing a SimpleTypeIdentifierSyntax") {
         final class SimpleTypeIdentifierSyntaxVisitor: SyntaxVisitor {
           var simpleTypeIdentifier: TypeDescription?
-          override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+          override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
             simpleTypeIdentifier = TypeSyntax(node).typeDescription
             return .skipChildren
           }
@@ -482,7 +482,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when called on a TypeSyntax node representing a MemberTypeIdentifierSyntax") {
         final class MemberTypeIdentifierSyntaxVisitor: SyntaxVisitor {
           var nestedTypeIdentifier: TypeDescription?
-          override func visit(_ node: MemberTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+          override func visit(_ node: MemberTypeSyntax) -> SyntaxVisitorContinueKind {
             nestedTypeIdentifier = TypeSyntax(node).typeDescription
             return .skipChildren
           }
@@ -556,7 +556,7 @@ final class TypeDescriptionSpec: QuickSpec {
           // Note: ideally we'd visit a node of type CompositionTypeElementListSyntax
           // but there's no easy way to get a TypeSyntax from an object of that type.
           override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {
-            composedTypeIdentifier = node.typeName.typeDescription
+            composedTypeIdentifier = node.type.typeDescription
             return .skipChildren
           }
         }
@@ -581,8 +581,8 @@ final class TypeDescriptionSpec: QuickSpec {
           var optionalTypeIdentifiers = [TypeDescription]()
           override func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
             optionalTypeIdentifiers += [
-              node.leftTypeIdentifier.typeDescription,
-              node.rightTypeIdentifier.typeDescription
+              node.leftType.typeDescription,
+              node.rightType.typeDescription
             ]
             return .skipChildren
           }
@@ -674,7 +674,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when called on a TypeSyntax node representing a SomeTypeSyntax") {
         final class SomeTypeSyntaxVisitor: SyntaxVisitor {
           var someTypeIdentifier: TypeDescription?
-          override func visit(_ node: ConstrainedSugarTypeSyntax) -> SyntaxVisitorContinueKind {
+          override func visit(_ node: SomeOrAnyTypeSyntax) -> SyntaxVisitorContinueKind {
             someTypeIdentifier = TypeSyntax(node).typeDescription
             return .skipChildren
           }
@@ -779,7 +779,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when called on a TypeSyntax node representing an array not of form ArrayTypeSyntax") {
         final class SimpleTypeIdentifierSyntaxVisitor: SyntaxVisitor {
           var typeIdentifier: TypeDescription?
-          override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+          override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
             typeIdentifier = TypeSyntax(node).typeDescription
             return .skipChildren
           }
@@ -845,7 +845,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when called on a TypeSyntax node representing a dictionary not of form DictionaryTypeSyntax") {
         final class SimpleTypeIdentifierSyntaxVisitor: SyntaxVisitor {
           var typeIdentifier: TypeDescription?
-          override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+          override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
             typeIdentifier = TypeSyntax(node).typeDescription
             return .skipChildren
           }
@@ -915,7 +915,7 @@ final class TypeDescriptionSpec: QuickSpec {
           // Note: ideally we'd visit a node of type ClassRestrictionTypeSyntax
           // but there's no way to get a TypeSyntax from an object of that type.
           override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {
-            classRestrictionIdentifier = node.typeName.typeDescription
+            classRestrictionIdentifier = node.type.typeDescription
             return .skipChildren
           }
         }

--- a/Sources/SwiftInspectorVisitors/Tests/TypeInheritanceVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeInheritanceVisitorSpec.swift
@@ -30,11 +30,11 @@ import SwiftInspectorTestHelpers
 @testable import SwiftInspectorVisitors
 
 final class TypeInheritanceVisitorSpec: QuickSpec {
-  private var sut = TypeInheritanceVisitor()
+  private var sut = TypeInheritanceVisitor(viewMode: .visitorDefault)
   
   override func spec() {
     beforeEach {
-      self.sut = TypeInheritanceVisitor()
+      self.sut = TypeInheritanceVisitor(viewMode: .visitorDefault)
     }
 
     describe("visit(_:)") {

--- a/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
@@ -30,12 +30,12 @@ public final class TypeInheritanceVisitor: SyntaxVisitor {
   public private(set) var inheritsFromTypes = [TypeDescription]()
 
   public override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {
-    inheritsFromTypes.append(node.typeName.typeDescription)
+    inheritsFromTypes.append(node.type.typeDescription)
     // Children don't have any more information about inheritance, so don't visit them.
     return .skipChildren
   }
 
-  public override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
+  public override func visit(_ node: MemberBlockSyntax) -> SyntaxVisitorContinueKind {
     // A member declaration block means we've found the body of the type.
     // There's nothing in this body that would help us determine type inheritance.
     .skipChildren

--- a/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
@@ -28,6 +28,7 @@ public final class TypealiasVisitor: SyntaxVisitor {
 
   public init(parentType: TypeDescription? = nil) {
     self.parentType = parentType
+    super.init(viewMode: .visitorDefault)
   }
 
   public private(set) var typealiases = [TypealiasInfo]()
@@ -35,26 +36,25 @@ public final class TypealiasVisitor: SyntaxVisitor {
   public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
     let name = node.identifier.text
 
-    let genericTypeVisitor = GenericParameterVisitor()
+    let genericTypeVisitor = GenericParameterVisitor(viewMode: .visitorDefault)
     if let genericParameterClause = node.genericParameterClause {
       genericTypeVisitor.walk(genericParameterClause)
     }
 
-    let genericRequirementVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor(viewMode: .visitorDefault)
     if let genericWhereClause = node.genericWhereClause {
       genericRequirementVisitor.walk(genericWhereClause)
     }
 
-    let declarationModifierVisitor = DeclarationModifierVisitor()
-    if let modifiers = node.modifiers {
-      declarationModifierVisitor.walk(modifiers)
-    }
+    let declarationModifierVisitor = DeclarationModifierVisitor(viewMode: .visitorDefault)
+    let modifiers = node.modifiers
+    declarationModifierVisitor.walk(modifiers)
 
     typealiases.append(
       .init(
         name: name,
         genericParameters: genericTypeVisitor.genericParameters,
-        initializer: node.initializer?.value.typeDescription,
+        initializer: node.initializer.value.typeDescription,
         genericRequirements: genericRequirementVisitor.genericRequirements,
         modifiers: declarationModifierVisitor.modifiers,
         parentType: parentType))

--- a/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
@@ -33,8 +33,8 @@ public final class TypealiasVisitor: SyntaxVisitor {
 
   public private(set) var typealiases = [TypealiasInfo]()
 
-  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
-    let name = node.identifier.text
+  public override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
+    let name = node.name.text
 
     let genericTypeVisitor = GenericParameterVisitor(viewMode: .visitorDefault)
     if let genericParameterClause = node.genericParameterClause {


### PR DESCRIPTION
The [swift-syntax](https://github.com/apple/swift-syntax) dependency is being updated for Swift 5.9 support.

Functionality has been tested by making sure all existing unit tests pass, with the required updates in the tests.

<img width="389" alt="image" src="https://github.com/pablocornejo/SwiftInspector/assets/40843954/387dab0c-8bd4-4947-9810-09d82e12c756">

Note: PR will be updated to use the release version of swift-syntax for Swift 5.9 before merging. Currently using tag [509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-15-a](https://github.com/apple/swift-syntax/releases/tag/509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-15-a)
